### PR TITLE
Update dependencies, add restore script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM debian:jessie-slim
+FROM debian:stretch-slim
 LABEL description="MongoDB cron backup to Google Cloud Storage (GCE)"
 LABEL maintainer="todd.mannherz@gmail.com"
 
-RUN apt-get update && \ 
-    apt-get install -qqy cron curl python
+RUN apt-get update && \
+    apt-get install -qqy cron curl python gnupg2
 
 # Install MongoDB tools
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F3730359A14518585931BC711F9BA15703C6 && \
-    echo "deb http://repo.mongodb.org/apt/debian jessie/mongodb-org/3.4 main" | tee /etc/apt/sources.list.d/mongodb-org-3.4.list && \
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 9DA31620334BD75D9DCB49F368818C72E52529D4 && \
+    echo "deb http://repo.mongodb.org/apt/debian stretch/mongodb-org/4.0 main" | tee /etc/apt/sources.list.d/mongodb-org-4.0.list && \
     apt-get update && \
     apt-get install -qqy mongodb-org-tools
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,9 @@ RUN curl -s -O https://storage.googleapis.com/pub/gsutil.tar.gz && \
 ENV CRON_SCHEDULE "0 6 * * *"
 RUN mkdir /backup
 COPY db_backup.sh /backup/
+COPY db_restore.sh /backup/
 RUN chmod +x /backup/db_backup.sh
+RUN chmod +x /backup/db_restore.sh
 
 # Docker logging from cron runs
 RUN ln -sf /proc/1/fd/1 /var/log/cron.log

--- a/db_restore.sh
+++ b/db_restore.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# MongoDB restore from GCS
+set -e
+echo "--------------------------------"
+
+# variables
+BACKUP_DIR=/backup
+DB_HOST="$MONGO_HOST"
+BUCKET_NAME="$GS_BACKUP_BUCKET"
+DATE=$(date +"%Y-%m-%d")
+FILE=$1.archive.gz
+
+cd $BACKUP_DIR
+
+if [ -z "$DB_HOST" ]; then
+    echo "DB_HOST is empty."
+    exit 1
+fi
+if [ -z "$BUCKET_NAME" ]; then
+    echo "BUCKET_NAME is empty."
+    exit 1
+fi
+
+# pull from GCS
+echo "Copying gs://$BUCKET_NAME/mongo/$FILE" to $BACKUP_DIR/$FILE
+/root/gsutil/gsutil cp gs://"$BUCKET_NAME"/mongo/$FILE $FILE 2>&1
+
+echo "Restoring the MongoDB archive"
+mongorestore -h "$DB_HOST" --gzip --archive="$FILE"
+
+echo "Restore complete."


### PR DESCRIPTION
May as well use the current stable Debian rather than oldstable.

Without the MongoDB update, the backup was failing against my 4.0 server.

Added a script which can be used to restore the backup from GCS to the running MongoDB instance using `mongorestore`.